### PR TITLE
fix: move set_theme to main function

### DIFF
--- a/src/tbp/plot/plots/objects_evidence_over_time.py
+++ b/src/tbp/plot/plots/objects_evidence_over_time.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-sns.set_theme(style="darkgrid")
 
 # NOTE: Copied from tbp.monty.frameworks.environments.ycb.py.
 # 10 objects that have little similarities in morphology.
@@ -65,6 +64,9 @@ def main(experiment_log_dir: str) -> int:
     if not Path(experiment_log_dir).exists():
         logger.error(f"Experiment path not found: {experiment_log_dir}")
         return 1
+
+    # seaborn darkgrid style
+    sns.set_theme(style="darkgrid")
 
     # load detailed stats
     json_file = Path(experiment_log_dir) / "detailed_run_stats.json"

--- a/src/tbp/plot/plots/pose_error_over_time.py
+++ b/src/tbp/plot/plots/pose_error_over_time.py
@@ -25,7 +25,6 @@ from tbp.plot.registry import attach_args, register
 if TYPE_CHECKING:
     import argparse
 
-sns.set_theme(style="darkgrid")
 logger = logging.getLogger(__name__)
 
 
@@ -55,6 +54,9 @@ def main(experiment_log_dir: str) -> int:
     if not Path(experiment_log_dir).exists():
         logger.error(f"Experiment path not found: {experiment_log_dir}")
         return 1
+
+    # seaborn darkgrid style
+    sns.set_theme(style="darkgrid")
 
     # load detailed stats
     json_file = Path(experiment_log_dir) / "detailed_run_stats.json"


### PR DESCRIPTION
This PR moves the line `sns.set_theme(style="darkgrid")` to the main function of the plots instead of globally defined. We do not want the theme set during imports.