### PR TITLE
chore: update cli to load the correct matplotlib backend

### DIFF
--- a/src/tbp/plot/cli.py
+++ b/src/tbp/plot/cli.py
@@ -50,10 +50,19 @@ def _configure_matplotlib_backend() -> None:
     for backend in candidates:
         try:
             importlib.import_module(f"matplotlib.backends.backend_{backend.lower()}")
-        except ImportError:
+        except (ImportError, RuntimeError):
             continue
         mpl.use(backend)
         return
+
+    print(
+        "Warning: no interactive matplotlib backend (QtAgg, Qt5Agg, TkAgg) could be "
+        "loaded. Plots may not display.\n"
+        "To fix this, install a GUI toolkit (e.g. `uv add pyqt6` or `uv add tk`) "
+        "or set the MPLBACKEND environment variable to a backend that works in your "
+        "environment.",
+        file=sys.stderr,
+    )
 
 
 def _print_list() -> None:


### PR DESCRIPTION
When I run any plots that contain matplotlib renders, I had to use a hack to set the backend to qt5 otherwise it just fails to create a matplotlib plot and exits without printing any errors. The hack was to add `matplotlib.use("Qt5Agg")` at the top of the plot.

This PR loads the Qt backend and falls back to tkinter if Qt is unavailable. The code is applied in the cli script before loading any plots. 

**Note that this code is written by an LLM and supervised by me.**